### PR TITLE
log.sleep -> time.sleep

### DIFF
--- a/bin/daq_online_monitor
+++ b/bin/daq_online_monitor
@@ -249,7 +249,7 @@ def undying_main(args):
                 raise
             except Exception:
                 pass
-            log.sleep(60)
+            time.sleep(60)
             log.warning('Restarting main loop')
 
 


### PR DESCRIPTION
Classic mistake